### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,17 @@ External viewers of your Git repo will just see hashes for your secret content w
 
 ## Usage
 
-Specify the plugin in your `netlify.yml`. No config is required but we show the default options here.
+To install, add the following lines to your `netlify.toml` file:
 
-```yml
-# netlify.yml
-build:
-  publish: build # NOTE: you should have a publish folder specified here for this to work
-  command: echo "your build command goes here"
-  NODE_ENV: 10.15.3
-
-plugins:
-  - package: netlify-plugin-encrypted-files
-    # no config required
-    # config:
-      # branches: # if specified, allow a small set of branches for which the decrypt is applied
-      # - master
-      # - swyx/myNewBranch
-    # dont forget to specify a NETLIFY_ENCRYPT_KEY env variable in Netlify's UI
+```toml
+[[plugins]]
+package = "netlify-plugin-encrypted-files"
+  # all inputs are optional. uncomment to apply
+  # [plugins.inputs]
+  # branches = [ # if specified, allow a small set of branches for which the decrypt is applied
+    # "master",
+    # "swyx/myNewBranch"
+  # ] # dont forget to specify a NETLIFY_ENCRYPT_KEY env variable in Netlify's UI
 ```
 
 In your local environment, install the plugin and run the `encrypt` CLI on your project specifying a glob filepath for what should be encrypted and what `NETLIFY_ENCRYPT_KEY` you intend to use, e.g.
@@ -70,15 +64,20 @@ The idea is:
 
 No configuration is required - by default the `decrypt`ing works on all Netlify Builds, but you can restrict it to a small set of branches you specify:
 
-```yml
-# netlify.yml
-plugins:
-  - package: netlify-plugin-encrypted-files
-    config:
-      branches: # if specified, allow a small set of branches for which the decrypt is applied
-      - master
-      - swyx/myNewBranch
-    # dont forget to specify a NETLIFY_ENCRYPT_KEY env variable in Netlify's UI
+```toml
+# netlify.toml
+[[plugins]]
+package = "netlify-plugin-encrypted-files"
+
+  [plugins.inputs]
+  
+  # if specified, allow a small set of branches for which the decrypt is applied
+  branches = [
+    "master",
+    "swyx/myNewBranch"
+  ] 
+  
+  # dont forget to specify a NETLIFY_ENCRYPT_KEY env variable in Netlify's UI
 ```
 
 ## For Collaborators


### PR DESCRIPTION
For greater simplicity and consistency with Netlify users’ existing configuration files, we’re deprecating experimental support for Netlify config files in YAML or JSON (https://github.com/netlify/build/issues/975).

To get new plugin users started on the right foot, I’m proposing updates for all plugin READMEs to use `netlify.toml` format in the installation instructions.

I've also made the following updates to reflect the current plugins API:
- Replaced `config` with `inputs`.

Also, I removed the `build` section of the sample config file, in order to match the format in other repos. The `publish` directory should be set for all builds, and if I read the code correctly, should be available to the plugin even if it's been set via the UI. Is the specified `NODE_ENV` required?