### PR TITLE
Rename `onInit`

### DIFF
--- a/demo/encrypt.test.js
+++ b/demo/encrypt.test.js
@@ -8,6 +8,6 @@ test('plugin fixture works', async () => {
     process.env.NETLIFY_ENCRYPT_KEY = 'test';
     const initPlugin = netlifyPlugin();
     console.log(`running ${initPlugin.name}`);
-    initPlugin.onInit();
+    initPlugin.onPreBuild();
   }).not.toThrow();
 });

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 module.exports = function netlify404nomore(conf) {
   return {
     name: 'netlify-plugin-encrypted-files',
-    onInit({ pluginConfig: { branches } }) {
+    onPreBuild({ pluginConfig: { branches } }) {
       console.log('decrypting files');
       if (branches && branches.includes(process.env.BRANCH)) {
         pluginDecrypt({});


### PR DESCRIPTION
The `onInit` event handler has been renamed to `onPreBuild` since those two are currently identical. This PR renames this handler.