### PR TITLE
Rename `pluginConfig` to `inputs`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const chalk = require('chalk');
 module.exports = function netlify404nomore(conf) {
   return {
     name: 'netlify-plugin-encrypted-files',
-    onInit({ pluginConfig: { branches } }) {
+    onInit({ inputs: { branches } }) {
       console.log('decrypting files');
       if (branches && branches.includes(process.env.BRANCH)) {
         pluginDecrypt({});


### PR DESCRIPTION
The `pluginConfig` argument has been renamed to `inputs`.